### PR TITLE
Выпадающее меню в markItUp по клику

### DIFF
--- a/frontend/components/ls-vendor/markitup/jquery.markitup.js
+++ b/frontend/components/ls-vendor/markitup/jquery.markitup.js
@@ -214,24 +214,20 @@
 						li = $('<li class="markItUpButton markItUpButton'+t+(i)+' '+(button.className||'')+'"><a href="" '+key+' title="'+title+'">'+(button.name||'')+'</a></li>')
 						.bind("contextmenu.markItUp", function() { // prevent contextmenu on mac and allow ctrl+click
 							return false;
-						}).bind('click.markItUp', function(e) {
-							e.preventDefault();
+						}).bind('click.markItUp', function() {
+							$('> ul', this).toggle();
+							$(document).one('click', function() { // close dropmenu if click outside
+								$('ul ul', header).hide();
+							});
+							return false;
 						}).bind("focusin.markItUp", function(){
-                            $$.focus();
+							$$.focus();
 						}).bind('mouseup', function() {
 							if (button.call) {
 								eval(button.call)();
 							}
 							setTimeout(function() { markup(button) },1);
 							return false;
-						}).bind('mouseenter.markItUp', function() {
-								$('> ul', this).show();
-								$(document).one('click', function() { // close dropmenu if click outside
-										$('ul ul', header).hide();
-									}
-								);
-						}).bind('mouseleave.markItUp', function() {
-								$('> ul', this).hide();
 						}).appendTo(ul);
 						if (button.dropMenu) {
 							levels.push(i);


### PR DESCRIPTION
Issue #43 

Выпадающее меню не очень удобно по наведению. Потеря таргета закрывает меню, а если оно вложенное — уже серьезная проблема добраться к нужному элементу. 

Протестировать можно, например, добавив в *editor.markup.js*:
```
{name: 'Test', className: 'test', dropMenu: [
    {name: 'Test2', className: 'test2', dropMenu: [
        {name: 'Test3', openWith: ' :test3: '},
        {name: 'Test4', openWith: ' :test4: '},
        {name: 'Test5', className: 'test5', dropMenu: [
            {name: 'Test6', openWith: ' :test6: '},
            {name: 'Test7', openWith: ' :test7: '}
        ]}
    ]},
    {name: 'Test8', openWith: ' :Test8: '}
]}
```