### PR TITLE
Update Entity.class.php

### DIFF
--- a/classes/engine/Entity.class.php
+++ b/classes/engine/Entity.class.php
@@ -170,7 +170,7 @@ abstract class Entity extends LsObject
      */
     public function _getDataOne($sKey)
     {
-        if (array_key_exists($sKey, $this->_aData)) {
+        if (!is_array($sKey) && array_key_exists($sKey, $this->_aData)) {
             return $this->_aData[$sKey];
         }
         return null;


### PR DESCRIPTION
Когда у таблицы составной первичный ключ, то $sKey - это массив. В результате появляется вот такой ворнинг
Warning: array_key_exists(): The first argument should be either a string or an integer in /home/kolya/www/c8/framework/classes/engine/Entity.class.php on line 173