### PR TITLE
Возможность добавлять выпадающему списку иконку

### DIFF
--- a/frontend/components/dropdown/dropdown.tpl
+++ b/frontend/components/dropdown/dropdown.tpl
@@ -39,6 +39,7 @@
             classes    = "{$component}-toggle js-{$component}-toggle"
             mods       = $mods
             text       = $smarty.local.text
+            icon       = $icon
             attributes = array_merge( $attributes|default:[], [
                 'aria-haspopup' => 'true',
                 'aria-expanded' => 'false'


### PR DESCRIPTION
в описании guide это было, а по факту нет.
По идее каждому элементу меню тоже бы надо такую возможность добавить.