### PR TITLE
Dismissible alerts fix

### DIFF
--- a/frontend/components/alert/alert.tpl
+++ b/frontend/components/alert/alert.tpl
@@ -12,12 +12,13 @@
 
 {* Название компонента *}
 {$component = 'ls-alert'}
-{component_define_params params=[ 'title', 'text', 'visible', 'dismissible', 'mods', 'classes', 'attributes' ]}
+{component_define_params params=[ 'title', 'text', 'visible', 'dismissible', 'close', 'mods', 'classes', 'attributes' ]}
 
 {* Дефолтные значения *}
 {$uid = "{$component}{rand( 0, 10e10 )}"}
 {$visible = $visible|default:true}
 
+{$dismissible = ( $close ) ? $close : $dismissible}
 {if $dismissible}
     {$mods = "$mods dismissible"}
 {/if}


### PR DESCRIPTION
По дефолту из шаблона юзается **close** [../layout.base.tpl#L127](https://github.com/livestreet/livestreet/blob/master/application/frontend/skin/developer/layouts/layout.base.tpl#L127)
+**close** легче запомнить и написать чем **dismissible**, поэтому считаю удобней внести правки именно в компонент