### PR TITLE
Исправлена проверка зависимости плагинов при деактивации плагина

### DIFF
--- a/classes/modules/plugin_manager/PluginManager.class.php
+++ b/classes/modules/plugin_manager/PluginManager.class.php
@@ -235,19 +235,29 @@ class ModulePluginManager extends ModuleORM
         /**
          * Проверяем на зависимость других плагинов через опцию requires
          */
+        $aPluginItemsAll = $this->PluginManager_GetPluginsItems();
         $iConflict = 0;
-        foreach ($aPluginItemsActive as $sPlugnCheck) {
-            foreach ($oXml->requires->plugins->children() as $sReqPlugin) {
-                if ($sReqPlugin == $sPlugin) {
-                    $iConflict++;
-                    $this->Message_AddError(
-                        $this->Lang_Get('admin.plugins.notices.deactivation_requires_error',
-                            array('plugin' => func_camelize($sPlugnCheck))),
-                        $this->Lang_Get('common.error.error'), true
-                    );
+
+        foreach ($aPluginItemsAll as $sPluginItemName => $oPluginItem) {
+            if (!$oPluginItem['is_active']) {
+                continue;
+            }
+
+            if ($oPluginItem['property']->requires->plugins) {
+                foreach ($oPluginItem['property']->requires->plugins->children() as $sReqPlugin) {
+                    if ($sReqPlugin == $sPlugin) {
+                        $iConflict++;
+                        $this->Message_AddError(
+                            $this->Lang_Get('admin.plugins.notices.deactivation_requires_error',
+                                array('plugin' => func_camelize($oPluginItem['code']))),
+                            $this->Lang_Get('common.error.error'),
+                            true
+                        );
+                    }
                 }
             }
         }
+
         if ($iConflict) {
             return false;
         }


### PR DESCRIPTION
Привет,

В оригинальном коде две проблемы:
1. Он не работает, т.е. он буквально ничего не проверяет. Каждую итерацию сравнивается список зависимостей отключаемого плагина
`$oXml = $this->GetPluginXmlInfo($sPlugin)`
`$oXml->requires->plugins->children()`
с названием отключаемого плагина ($sPlugin). То есть проверяется есть ли текущий плагин в зависимостях у самого себя.

2. Если у отключаемого плагина отсутствует в requires секция plugins, то при его деактивации свалится столько Warning-ов сколько плагинов в данный момент активировано
`Warning: ModulePluginManager::DeactivatePlugin(): Node no longer exists in /framework/classes/modules/plugin_manager/PluginManager.class.php on line 240`

Примечание: текстовки admin.* отсутствуют во фреймворке, но они есть в cms. Их надо бы перенести во фреймворк.