### PR TITLE
field disable mods

### DIFF
--- a/frontend/components/field/field.tpl
+++ b/frontend/components/field/field.tpl
@@ -33,6 +33,10 @@
 {$form = $form|default:$_aRequest}
 {$getValueFromForm = true}
 
+{if $isDisabled}
+    {$mods = "$mods disabled"}
+{/if}
+
 {* Правила валидации *}
 {if $entity}
     {field_make_rule entity=$entity field=$entityField|default:$name scenario=$entityScenario assign=rules}


### PR DESCRIPTION
В таком случае будет возможность стилизовать заблоченный блок поля с помощью класса **ls-field--disabled**

сейчас, если нужно стилизовать например label у заблоченного поля, придется написать сломай-мозг-селектор (если вообще возможно)