### PR TITLE
Hooks by preg

### DIFF
--- a/classes/engine/Hook.class.php
+++ b/classes/engine/Hook.class.php
@@ -63,6 +63,22 @@ abstract class Hook extends LsObject
     }
 
     /**
+     * Добавляет обработчик на хук по регулярному выражению
+     *
+     * @param string $sName Название хука на который вешается обработчик
+     * @param string $sCallBack Название метода обработчика
+     * @param null|string $sClassNameHook Название класса обработчика, по умолчанию это текущий класс хука
+     * @param int $iPriority Приоритет обработчика хука, чем выше число, тем больше приоритет - хук обработчик выполнится раньше остальных
+     */
+    protected function AddHookPreg($sName, $sCallBack, $sClassNameHook = null, $iPriority = 1)
+    {
+        if (is_null($sClassNameHook)) {
+            $sClassNameHook = get_class($this);
+        }
+        $this->Hook_AddExecHook($sName, $sCallBack, $iPriority, array('sClassName' => $sClassNameHook), true);
+    }
+
+    /**
      * Обязательный метод в хуке - в нем происходит регистрация обработчиков хуков
      *
      * @abstract


### PR DESCRIPTION
- Добавил возможность регистрации хуков по регулярному выражению.
- В функцию вторым аргументом передается название хука.

Тестировалось так:

**Input**
`$this->AddHookPreg('/^template_nav_(.+)$/i', 'NavTest');`

```
public function NavTest($aVars, $sHookName)
{
	$this->Logger_Error('__Run preg hook', array('name' => $sHookName));
}
```

**Output (на проекте много менюшек)**

> [2017-03-10 20:49:09] default.ERROR 10648 389d8fb: __Run preg hook {"name":"template_nav_user"}
> [2017-03-10 20:49:09] default.ERROR 10648 389d8fb: __Run preg hook {"name":"template_nav_main"}
> [2017-03-10 20:49:09] default.ERROR 10648 389d8fb: __Run preg hook {"name":"template_nav_baby"}
> [2017-03-10 20:49:09] default.ERROR 10648 389d8fb: __Run preg hook {"name":"template_nav_index"}
> [2017-03-10 20:49:09] default.ERROR 10648 389d8fb: __Run preg hook {"name":"template_nav_footer_menu_main"}
> [2017-03-10 20:49:09] default.ERROR 10648 389d8fb: __Run preg hook {"name":"template_nav_footer_menu_blog"}
> [2017-03-10 20:49:09] default.ERROR 10648 389d8fb: __Run preg hook {"name":"template_nav_footer_menu_forum"}