### PR TITLE
libmemcached multiget fix

### DIFF
--- a/classes/modules/cache/entity/BackendLibmemcached.entity.class.php
+++ b/classes/modules/cache/entity/BackendLibmemcached.entity.class.php
@@ -47,7 +47,7 @@ class ModuleCache_EntityBackendLibmemcached extends ModuleCache_EntityBackend
      */
     public function IsAllowMultiGet()
     {
-        return true;
+        return false;
     }
 
     /**


### PR DESCRIPTION

```
Warning: Memcached::get() expects parameter 1 to be string, array given in /var/www/html/framework/libs/vendor/DklabCache/Zend/Cache/Backend/Libmemcached.php on line 166
```