### PR TITLE
Module Database fix

### DIFF
--- a/classes/modules/database/Database.class.php
+++ b/classes/modules/database/Database.class.php
@@ -230,7 +230,7 @@ class ModuleDatabase extends Module
             if ($sQuery != '') {
                 $bResult = $this->GetConnect($aConfig)->query($sQuery);
                 if ($bResult === false) {
-                    $aErrors[] = mysql_error();
+                    $aErrors[] = mysqli_error();
                 }
             }
         }


### PR DESCRIPTION
`[2017-05-14 15:04:00] default.ERROR 9764 2c1ad81: Uncaught Exception Error: "Call to undefined function mysql_error()" at путь_до\framework\classes\modules\database\Database.class.php line 233 {"exception":"[object] (Error(code: 0): Call to undefined function mysql_error() at путь_до\\framework\\classes\\modules\\database\\Database.class.php:233)"}
`