### PR TITLE
Применение фильтра #index-from для сущностей RELATION_TYPE_MANY_TO_MANY

### DIFF
--- a/classes/engine/MapperORM.class.php
+++ b/classes/engine/MapperORM.class.php
@@ -296,7 +296,11 @@ class MapperORM extends Mapper
                 $oEntity->_setDataFromDb($aData);
                 unset($aData['_relation_entity']);
                 $oEntity->_setOriginalData($aData);
-                $aItems[] = $oEntity;
+                if (isset($aFilter['#index-from']) && $oEntity->_getDataOne($aFilter['#index-from']) !== ''){
+                    $aItems[$oEntity->_getDataOne($aFilter['#index-from'])] = $oEntity;
+                } else {
+                    $aItems[] = $oEntity;
+                }
             }
         }
         return $aItems;


### PR DESCRIPTION
Для связей сущности типа RELATION_TYPE_MANY_TO_MANY не работало формирование массива данных по ключу из поля.